### PR TITLE
[v12] AppV2 improvements

### DIFF
--- a/css/boilerplate.css
+++ b/css/boilerplate.css
@@ -244,17 +244,6 @@
 .boilerplate .sheet-header .header-fields {
   flex: 1;
 }
-.boilerplate .sheet-header h1.charname {
-  height: 50px;
-  padding: 0px;
-  margin: 5px 0;
-  border-bottom: 0;
-}
-.boilerplate .sheet-header h1.charname input {
-  width: 100%;
-  height: 100%;
-  margin: 0;
-}
 .boilerplate .sheet-tabs {
   flex: 0;
 }

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -88,6 +88,9 @@ export class BoilerplateActorSheet extends api.HandlebarsApplicationMixin(
     const context = {
       // Validates both permissions and compendium status
       editable: this.isEditable,
+      owner: this.isOwner,
+      limited: this.document.limited,
+      // Add the actor document.
       actor: this.actor,
       // Add the actor's data to context.data for easier access, as well as flags.
       system: this.actor.system,

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -85,6 +85,11 @@ export class BoilerplateItemSheet extends api.HandlebarsApplicationMixin(
   /** @override */
   async _prepareContext(options) {
     const context = {
+      // Validates both permissions and compendium status
+      editable: this.isEditable,
+      owner: this.isOwner,
+      limited: this.document.limited,
+      // Add the item document.
       item: this.item,
       // Adding system and flags for easier access
       system: this.item.system,

--- a/src/datamodels/module/sheets/actor-sheet.mjs
+++ b/src/datamodels/module/sheets/actor-sheet.mjs
@@ -88,6 +88,9 @@ export class BoilerplateActorSheet extends api.HandlebarsApplicationMixin(
     const context = {
       // Validates both permissions and compendium status
       editable: this.isEditable,
+      owner: this.isOwner,
+      limited: this.document.limited,
+      // Add the actor document.
       actor: this.actor,
       // Add the actor's data to context.data for easier access, as well as flags.
       system: this.actor.system,

--- a/src/datamodels/module/sheets/item-sheet.mjs
+++ b/src/datamodels/module/sheets/item-sheet.mjs
@@ -85,6 +85,11 @@ export class BoilerplateItemSheet extends api.HandlebarsApplicationMixin(
   /** @override */
   async _prepareContext(options) {
     const context = {
+      // Validates both permissions and compendium status
+      editable: this.isEditable,
+      owner: this.isOwner,
+      limited: this.document.limited,
+      // Add the item document.
       item: this.item,
       // Adding system and flags for easier access
       system: this.item.system,

--- a/src/scss/components/_forms.scss
+++ b/src/scss/components/_forms.scss
@@ -20,18 +20,6 @@
   .header-fields {
     flex: 1;
   }
-
-  h1.charname {
-    height: 50px;
-    padding: 0px;
-    margin: 5px 0;
-    border-bottom: 0;
-    input {
-      width: 100%;
-      height: 100%;
-      margin: 0;
-    }
-  }
 }
 
 .sheet-tabs {

--- a/templates/actor/header.hbs
+++ b/templates/actor/header.hbs
@@ -9,7 +9,7 @@
     width='100'
   />
   <div class='header-fields'>
-    <div class='charname'>
+    <div class='document-name'>
       <input
         name='name'
         type='text'

--- a/templates/item/header.hbs
+++ b/templates/item/header.hbs
@@ -6,9 +6,9 @@
     title='{{item.name}}'
   />
   <div class='header-fields'>
-    <h1 class='charname'>
+    <div class='document-name'>
       <input name='name' type='text' value='{{item.name}}' placeholder='Name' />
-    </h1>
+    </div>
     {{! You may prefer to have a separate header file instead of this if statement}}
     {{#if (eq item.type 'gear')}}
       <div class='grid grid-2col'>


### PR DESCRIPTION
- Added permissions to actor and item sheet contexts, particularly the `editable` permission which was preventing the description tab from working on items.
- Replaced `<h1>` tag on item sheets with a div. Also renamed the name field's class from `charname` to `document-name`.
- Removed references to `charname` from the SCSS and CSS.