### PR TITLE
Add support for changing avatars

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -22,6 +22,7 @@ export class BoilerplateActorSheet extends api.HandlebarsApplicationMixin(
       height: 600,
     },
     actions: {
+      onEditImage: this._onEditImage,
       viewDoc: this._viewDoc,
       createDoc: this._createDoc,
       deleteDoc: this._deleteDoc,
@@ -269,6 +270,33 @@ export class BoilerplateActorSheet extends api.HandlebarsApplicationMixin(
    *   ACTIONS
    *
    **************/
+
+  /**
+   * Handle changing a Document's image.
+   * 
+   * @this GrimwildActorSheet
+   * @param {PointerEvent} event   The originating click event
+   * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
+   * @returns {Promise}
+   * @protected
+   */
+  static async _onEditImage(event, target) {
+    const attr = target.dataset.edit;
+    const current = foundry.utils.getProperty(this.document, attr);
+    const { img } = this.document.constructor.getDefaultArtwork?.(this.document.toObject()) ?? {};
+    const fp = new FilePicker({
+      current,
+      type: "image",
+      redirectToRoot: img ? [img] : [],
+      callback: path => {
+        target.src = path;
+        this.document.update({'img': path});
+      },
+      top: this.position.top + 40,
+      left: this.position.left + 10
+    });
+    return fp.browse();
+  }
 
   /**
    * Renders an embedded document's sheet

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -18,6 +18,7 @@ export class BoilerplateItemSheet extends api.HandlebarsApplicationMixin(
   static DEFAULT_OPTIONS = {
     classes: ['boilerplate', 'item'],
     actions: {
+      onEditImage: this._onEditImage,
       viewDoc: this._viewEffect,
       createDoc: this._createEffect,
       deleteDoc: this._deleteEffect,
@@ -203,6 +204,33 @@ export class BoilerplateItemSheet extends api.HandlebarsApplicationMixin(
    *   ACTIONS
    *
    **************/
+
+  /**
+   * Handle changing a Document's image.
+   * 
+   * @this GrimwildActorSheet
+   * @param {PointerEvent} event   The originating click event
+   * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
+   * @returns {Promise}
+   * @protected
+   */
+  static async _onEditImage(event, target) {
+    const attr = target.dataset.edit;
+    const current = foundry.utils.getProperty(this.document, attr);
+    const { img } = this.document.constructor.getDefaultArtwork?.(this.document.toObject()) ?? {};
+    const fp = new FilePicker({
+      current,
+      type: "image",
+      redirectToRoot: img ? [img] : [],
+      callback: path => {
+        target.src = path;
+        this.document.update({'img': path});
+      },
+      top: this.position.top + 40,
+      left: this.position.left + 10
+    });
+    return fp.browse();
+  }
 
   /**
    * Renders an embedded document's sheet

--- a/src/datamodels/module/sheets/actor-sheet.mjs
+++ b/src/datamodels/module/sheets/actor-sheet.mjs
@@ -22,6 +22,7 @@ export class BoilerplateActorSheet extends api.HandlebarsApplicationMixin(
       height: 600,
     },
     actions: {
+      onEditImage: this._onEditImage,
       viewDoc: this._viewDoc,
       createDoc: this._createDoc,
       deleteDoc: this._deleteDoc,
@@ -272,6 +273,33 @@ export class BoilerplateActorSheet extends api.HandlebarsApplicationMixin(
    *   ACTIONS
    *
    **************/
+
+  /**
+   * Handle changing a Document's image.
+   * 
+   * @this GrimwildActorSheet
+   * @param {PointerEvent} event   The originating click event
+   * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
+   * @returns {Promise}
+   * @protected
+   */
+  static async _onEditImage(event, target) {
+    const attr = target.dataset.edit;
+    const current = foundry.utils.getProperty(this.document, attr);
+    const { img } = this.document.constructor.getDefaultArtwork?.(this.document.toObject()) ?? {};
+    const fp = new FilePicker({
+      current,
+      type: "image",
+      redirectToRoot: img ? [img] : [],
+      callback: path => {
+        target.src = path;
+        this.document.update({'img': path});
+      },
+      top: this.position.top + 40,
+      left: this.position.left + 10
+    });
+    return fp.browse();
+  }
 
   /**
    * Renders an embedded document's sheet

--- a/src/datamodels/module/sheets/item-sheet.mjs
+++ b/src/datamodels/module/sheets/item-sheet.mjs
@@ -18,6 +18,7 @@ export class BoilerplateItemSheet extends api.HandlebarsApplicationMixin(
   static DEFAULT_OPTIONS = {
     classes: ['boilerplate', 'item'],
     actions: {
+      onEditImage: this._onEditImage,
       viewDoc: this._viewEffect,
       createDoc: this._createEffect,
       deleteDoc: this._deleteEffect,
@@ -206,6 +207,33 @@ export class BoilerplateItemSheet extends api.HandlebarsApplicationMixin(
    *   ACTIONS
    *
    **************/
+
+  /**
+   * Handle changing a Document's image.
+   * 
+   * @this GrimwildActorSheet
+   * @param {PointerEvent} event   The originating click event
+   * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
+   * @returns {Promise}
+   * @protected
+   */
+  static async _onEditImage(event, target) {
+    const attr = target.dataset.edit;
+    const current = foundry.utils.getProperty(this.document, attr);
+    const { img } = this.document.constructor.getDefaultArtwork?.(this.document.toObject()) ?? {};
+    const fp = new FilePicker({
+      current,
+      type: "image",
+      redirectToRoot: img ? [img] : [],
+      callback: path => {
+        target.src = path;
+        this.document.update({'img': path});
+      },
+      top: this.position.top + 40,
+      left: this.position.left + 10
+    });
+    return fp.browse();
+  }
 
   /**
    * Renders an embedded document's sheet

--- a/templates/actor/header.hbs
+++ b/templates/actor/header.hbs
@@ -4,6 +4,7 @@
     class='profile-img'
     src='{{actor.img}}'
     data-edit='img'
+    data-action='onEditImage'
     title='{{actor.name}}'
     height='100'
     width='100'

--- a/templates/item/header.hbs
+++ b/templates/item/header.hbs
@@ -3,6 +3,7 @@
     class='profile-img'
     src='{{item.img}}'
     data-edit='img'
+    data-action='onEditImage'
     title='{{item.name}}'
   />
   <div class='header-fields'>


### PR DESCRIPTION
- Added `_onEditImage()` method to actor and item sheets to support changing actor/item avatars.
- Updated header.hbs templates to use the new actions.